### PR TITLE
Token required

### DIFF
--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -493,9 +493,7 @@ bool AuthSocket::_HandleLogonChallenge()
                             const int requireTokensForGMLevel = sConfig.GetIntDefault("RequireTokensFor", -1);
                             const bool tokenOverride = secLevel >= requireTokensForGMLevel;
                             if ( tokenOverride )
-                                DEBUG_LOG("[Auth] Overriding token requirements for %s",self->_login.c_str());
-                            else
-                                DEBUG_LOG("[AUTH] AccountSecurityLevel: %u, RequireTokensForGMLevel: %d",secLevel,requireTokensForGMLevel);
+                                DEBUG_LOG("[Auth] Overriding token requirements for %s with gmlevel %u",self->_login.c_str(),secLevel);
 
                             self->_token = fields[6].GetCppString();
 

--- a/src/realmd/AuthSocket.cpp
+++ b/src/realmd/AuthSocket.cpp
@@ -374,7 +374,7 @@ bool AuthSocket::_HandleLogonChallenge()
             self->_login = (const char*)body->userName;
             self->_build = body->build;
 
-            // Convert uint8[4] to string, reRequireTokensForstore string order as its byte order is reversed
+            // Convert uint8[4] to string, restore string order as its byte order is reversed
             body->os[3] = '\0';
             self->m_os = (char*)body->os;
             std::reverse(self->m_os.begin(), self->m_os.end());

--- a/src/realmd/realmd.conf.dist.in
+++ b/src/realmd/realmd.conf.dist.in
@@ -111,6 +111,17 @@ ConfVersion=2021031501
 #        Default:     0 - (Disabled)
 #                     1 - (Enabled)
 #
+#    RequireTokensFor
+#        Description: Require ToTP (Authenticators) for accounts this level and higher. 
+#           wotlkrealmd.account.token should be set to at least a 20 character, recommend 40 character, long 
+#           randomly generatedkey string containing only uppercase and numbers. 
+#           QR code string: otpauth://totp/{LABEL}?secret={GENERATEDKEY}
+#        Default:    -1 - (Disabled)
+#                     0 - (Players)
+#                     1 - (Moderators)
+#                     2 - (GameMasters)
+#                     3 - (Administrators)
+#
 #    WrongPass.MaxCount
 #        Number of login attemps with wrong password before the account or IP is banned
 #        Default: 0  (Never ban)
@@ -144,6 +155,7 @@ ProcessPriority = 1
 WaitAtStartupError = 0
 RealmsStateUpdateDelay = 20
 StrictVersionCheck = 0
+RequireTokensFor = -1
 WrongPass.MaxCount = 0
 WrongPass.BanTime = 600
 WrongPass.BanType = 0


### PR DESCRIPTION
## 🍰 Pullrequest
Allows for the configuration option to require ToTP (2FA) for accounts of specific levels.

### Proof
- None

### Issues
- None

### How2Test
* Verify you have updated the realmd.conf
* Set `RequireTokensFor` to 0
* Log in with any account and get prompted for a token
* Set `RequireTokensFor ` to 1
* Log in with a user account and no token prompt
* Log in with any moderator or above and get prompted for a token- None

### Todo / Checklist
- [X] None
